### PR TITLE
fix: Remove CONNECTION_REUSE env variable, it doesn't do anything in V3 sdk.

### DIFF
--- a/src/llrt-function.ts
+++ b/src/llrt-function.ts
@@ -23,6 +23,7 @@ export class LlrtFunction extends NodejsFunction {
 
     const cacheDir = `.tmp/llrt/${version}/${arch}`;
     super(scope, id, {
+      awsSdkConnectionReuse: false,
       ...props,
       bundling: {
         target: 'es2020',

--- a/test/llrt-function.integ.snapshot/LlrtFunctionIntegTest.template.json
+++ b/test/llrt-function.integ.snapshot/LlrtFunctionIntegTest.template.json
@@ -99,11 +99,6 @@
       "Arn"
      ]
     },
-    "Environment": {
-     "Variables": {
-      "AWS_NODEJS_CONNECTION_REUSE_ENABLED": "1"
-     }
-    },
     "Handler": "index.handler",
     "Runtime": "provided.al2023"
    },


### PR DESCRIPTION
I was doing some research and found that when you set environment variables with Lambda, it adds ~20ms in your E2E coldstart time.  This is due to Lambda making an additional call to `sts:AssumeRole` and `kms:Decrypt` to access the environment variables. I also discovered that the CDK always sets the environment variable `AWS_NODEJS_CONNECTION_REUSE_ENABLED`, but it has been deprecated in the [AWS JavaScript V3 SDK](https://github.com/aws/aws-sdk-js-v3/issues/5883). In V3 connection reuse is turned on by default and the variable doesn't actually do anything.  This change makes it so the `AWS_NODEJS_CONNECTION_REUSE_ENABLED` variable isn't set. If you aren't using environment variables you get faster coldstarts.

*Note* the 20ms latency doesn't appear in your Init Duration, it shows up in the E2E of a request when you call InvokeFunction and it is a coldstart.