### PR TITLE
fix: update binary type examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ npm install cdk-lambda-llrt
 Then you can use `LlrtFunction` construct. Just set an entry point for the function.
 
 ```ts
-import { LlrtFunction, LlrtBundleType } from 'cdk-lambda-llrt';
+import { LlrtFunction, LlrtBinaryType } from 'cdk-lambda-llrt';
 
 const handler = new LlrtFunction(this, 'Handler', {
     entry: 'lambda/index.ts',
-    bundleType: LlrtBundleType.FULL_SDK, // Optional: Choose between FULL_SDK, NO_SDK, or STANDARD (default)
+    binaryType: LlrtBinaryType.FULL_SDK, // Optional: Choose between FULL_SDK, NO_SDK, or STANDARD (default)
 });
 ```
 
@@ -32,7 +32,7 @@ If you want to upgrade the LLRT version, remove the `.tmp` directory, which cont
 In some cases, your code may run successfully on LLRT by setting bundle target platform to `browser`. You can configure it by the following code:
 
 ```ts
-import { LlrtFunction, LlrtBundleType } from 'cdk-lambda-llrt';
+import { LlrtFunction } from 'cdk-lambda-llrt';
 
 const handler = new LlrtFunction(this, 'Handler', {
     entry: 'lambda/index.ts',

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ import { LlrtFunction, LlrtBinaryType } from 'cdk-lambda-llrt';
 
 const handler = new LlrtFunction(this, 'Handler', {
     entry: 'lambda/index.ts',
-    binaryType: LlrtBinaryType.FULL_SDK, // Optional: Choose between FULL_SDK, NO_SDK, or STANDARD (default)
+    llrtBinaryType: LlrtBinaryType.FULL_SDK, // Optional: Choose between FULL_SDK, NO_SDK, or STANDARD (default)
 });
 ```
 
@@ -69,7 +69,7 @@ You can specify the binary type when creating a new `LlrtFunction`:
 ```ts
 const handler = new LlrtFunction(this, 'Handler', {
     entry: 'lambda/index.ts',
-    binaryType: LlrtBinaryType.FULL_SDK,
+    llrtBinaryType: LlrtBinaryType.FULL_SDK,
 });
 ```
 


### PR DESCRIPTION
Seems to have been missed in #9