### PR TITLE
feat!: commandHook override is now merged instead of overwritten

### DIFF
--- a/example/index.ts
+++ b/example/index.ts
@@ -80,6 +80,19 @@ class LlrtFunctionTestStack extends Stack {
     {
       const handler = new LlrtFunction(this, 'Ssr', {
         entry: '../example/lambda/ssr.tsx',
+        bundling: {
+          commandHooks: {
+            beforeBundling: (_i, _o) => {
+              return ['echo beforeBundling'];
+            },
+            afterBundling: (_i, _o) => {
+              return ['echo afterBundling'];
+            },
+            beforeInstall: (_i, _o) => {
+              return ['echo beforeInstall'];
+            },
+          },
+        },
       });
 
       const resource = api.root.addResource('ssr');

--- a/test/integ.llrt-function.ts
+++ b/test/integ.llrt-function.ts
@@ -17,6 +17,19 @@ class TestStack extends Stack {
       const handler = new LlrtFunction(this, 'Handler', {
         entry: '../example/lambda/s3.ts',
         llrtVersion: 'v0.2.2-beta',
+        bundling: {
+          commandHooks: {
+            beforeBundling: (_i, _o) => {
+              return ['echo beforeBundling'];
+            },
+            afterBundling: (_i, _o) => {
+              return ['echo afterBundling'];
+            },
+            beforeInstall: (_i, _o) => {
+              return ['echo beforeInstall'];
+            },
+          },
+        },
       });
       handler.addToRolePolicy(
         new PolicyStatement({


### PR DESCRIPTION
Fixes #13 

This can be a breaking change to some users, so bumping the minor version.

BREAKING CHANGE:
Users who set `bundling.commandHooks` see now cdk-lambda-llrt's commandHooks are also executed. Please verify your bundling works after the change.