### PR TITLE
chore: enable npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,5 +123,5 @@ jobs:
           NPM_DIST_TAG: latest
           NPM_REGISTRY: registry.npmjs.org
           NPM_CONFIG_PROVENANCE: "true"
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TRUSTED_PUBLISHER: "true"
         run: npx -p publib@latest publib-npm

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -20,6 +20,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
   npmIgnoreOptions: {
     ignorePatterns: ['/example/lambda/node_modules', '/example/lambda/.llrt'],
   },
+  npmTrustedPublishing: true,
   packageManager: NodePackageManager.NPM,
   gitignore: ['*.js', '*.d.ts', '!test/.*.snapshot/**/*', '.tmp'],
   keywords: ['aws', 'cdk', 'lambda', 'aws-cdk'],


### PR DESCRIPTION
similarly to: https://github.com/tmokmss/deploy-time-build/pull/60